### PR TITLE
Use Hooks in Selenium Cucumber Framework

### DIFF
--- a/src/test/java/stepDefinitions/CheckoutPageSteps.java
+++ b/src/test/java/stepDefinitions/CheckoutPageSteps.java
@@ -41,8 +41,6 @@ public class CheckoutPageSteps {
 		Thread.sleep(5000);
 		checkoutPage.checkTermsAndCondition(true);
 		checkoutPage.clickPlaceOrder();
-
-		testContext.getWebDriverManager().quiteDriver();
 	}
 
 }

--- a/src/test/java/stepDefinitions/Hooks.java
+++ b/src/test/java/stepDefinitions/Hooks.java
@@ -1,0 +1,34 @@
+package stepDefinitions;
+
+import com.deesite.cucumber.TestContext;
+
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+
+public class Hooks {
+	TestContext testContext;
+	public Hooks(TestContext context) {
+		this.testContext=context;
+	}
+	
+	@Before
+	public void BeforeSteps() {
+		/*
+		 What all you can perform here
+		 Starting a webdriver
+		 Setting up  DB connection
+		 Setting up test data
+		 Setting up browser cookies
+		 Navigating to certain page
+		 or anything before the test
+		 */
+	}
+	
+	@After
+	public void AfterSteps() {
+		testContext.getWebDriverManager().quiteDriver();
+	}
+	
+	
+
+}


### PR DESCRIPTION
How to use Hooks in Selenium Cucumber Framework?
Unlike TestNG Annotations, cucumber supports only two hooks (Before & After) which work at the start and the end of the test scenario. As the name suggests, @before hook gets executed well before any other test scenario, and @after hook gets executed after executing the scenario.
1. Create a New Class file and name it as Hooks by right click on the stepDefinitions package select New >> Class.
Hooks.java

Things to note
• An important thing to note about the after hook is that even in case of test fail, after hook will execute for sure.
• Method name can be anything, need not be beforeScenario() or afterScenario(). can also be named as setUp() and tearDown().
• Make sure that the package import statement should be import cucumber.api.java.After; & import cucumber.api.java.Before;
Often people mistaken and import Junit Annotations, so be careful with
this.
• Also make sure to remove
the testContext.getWebDriverManager().quitDriver(); from
the place_the_order() method of the CheckoutPageSteps class.
• We have not started our driver in the @Before method, because we have been doing the same in the TestContext class constructor. Because our PageObjectModel needs the driver at the early stage.
• The rest of the project does not have nay change. So in case you need the code for the whole project, please visit previous chapters of Selenium Cucumber Framework Series.